### PR TITLE
Fix teleporting cursor when using c_ commands in vim command mode

### DIFF
--- a/src/transaction-filter.ts
+++ b/src/transaction-filter.ts
@@ -13,6 +13,9 @@ export const makeTransactionFilter = (plugin: NoMoreFlicker): Extension => {
         const userEvent = tr.annotation(Transaction.userEvent)?.split('.')[0];
 
         if (userEvent === 'input') {
+			// Prevent issues with vim c_ commands
+			if (!tr.changes.inserted.length) return tr;
+			
             if (plugin.settings.disableOnIME) {
                 // Do nothing when the user is using IME input to avoid troubles that happen
                 // when using Latex Suite's tabout feature to escape from a math and then typing

--- a/src/transaction-filter.ts
+++ b/src/transaction-filter.ts
@@ -13,9 +13,15 @@ export const makeTransactionFilter = (plugin: NoMoreFlicker): Extension => {
         const userEvent = tr.annotation(Transaction.userEvent)?.split('.')[0];
 
         if (userEvent === 'input') {
-			// Prevent issues with vim c_ commands
-			if (!tr.changes.inserted.length) return tr;
-			
+            // https://github.com/RyotaUshio/obsidian-inline-math/pull/9
+            // Do nothing if there is no actual text insertion
+            // to prevent issues with vim commands such as cw, ciw, dw, etc.
+            let hasInsertion = false;
+            tr.changes.iterChanges((fromA, toA, fromB, toB, inserted) => {
+                hasInsertion ||= inserted.length > 0;
+            });
+            if (!hasInsertion) return tr;
+
             if (plugin.settings.disableOnIME) {
                 // Do nothing when the user is using IME input to avoid troubles that happen
                 // when using Latex Suite's tabout feature to escape from a math and then typing


### PR DESCRIPTION
When using vim keybindings, if you do a command like "cw" (change word - this deletes the remainder of the word you're on and puts you in insert mode) or "ciw" (change inner word - similar but deletes the whole word), this plugin's insertions of "{}" causes the cursor to teleport three spaces to the left.

My proposed change stops the plugin acting if there was no text input on the "input" userEvent. I think the plugin still works as expected and I can now use my c_ commands without crying.